### PR TITLE
Deleted tabs permission from manifest.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# openBD情報チェッカー（Google Chrome拡張機能） [![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/ttsukagoshi/chrome-ext_openBD-checker.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/ttsukagoshi/chrome-ext_openBD-checker/context:javascript)
+# openBD情報チェッカー（Google Chrome拡張機能）
+![Chrome Web Store](https://img.shields.io/chrome-web-store/v/jmbcpombnleepfponcjibgeohkfcocgg) [![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/ttsukagoshi/chrome-ext_openBD-checker.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/ttsukagoshi/chrome-ext_openBD-checker/context:javascript)  
 ウェブブラウザ（Chrome）内で選択したISBNコードに基づいて、コンテクストメニュー（右クリックメニュー）から[openBD](https://openbd.jp/)に登録されている情報を参照できるようにする拡張機能。
 
 ## インストール

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,10 +1,9 @@
 {
     "name": "openBD情報チェッカー",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "description": "openBDに登録されている書誌・書影情報を、コンテクストメニューからISBNで検索・参照する。",
     "permissions": [
         "contextMenus",
-        "tabs",
         "storage",
         "https://api.openbd.jp/"
     ],


### PR DESCRIPTION
# Deleted `tabs` permission from manifest.json
since this was not required to execute the extension.

# Others
Addressed minor alerts from LGTM.com
- Substituted missing semicolon at end of line
- Deleted unnecessary variable declaration `let`